### PR TITLE
docs(changelogs): fix Jelly Bean release year (2002 -> 2012)

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/406.txt
+++ b/fastlane/metadata/android/en-US/changelogs/406.txt
@@ -1,4 +1,4 @@
-This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2002) or later.
+This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2012) or later.
 
 Changes:
 

--- a/fastlane/metadata/android/en-US/changelogs/407.txt
+++ b/fastlane/metadata/android/en-US/changelogs/407.txt
@@ -1,4 +1,4 @@
-This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2002) or later.
+This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2012) or later.
 
 Changes:
 

--- a/fastlane/metadata/android/en-US/changelogs/408.txt
+++ b/fastlane/metadata/android/en-US/changelogs/408.txt
@@ -1,6 +1,6 @@
 # Changes in IntentIntercept from Version 4.0.7 (407) 2025-06-22 to 4.1.0 (408)
 
-This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2002) or later.
+This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2012) or later.
 
 ## new features:
 


### PR DESCRIPTION
## Summary

Per #43, three F-Droid/fastlane changelog entries (406, 407, 408) noted:

> This apk requires minSdk-16=Android-4.1=JELLY_BEAN (released in 2002) or later.

Android 4.1 (Jelly Bean) actually shipped in July 2012; 2002 pre-dates Android itself. Corrected the year in all three files.

Closes #43